### PR TITLE
Adding environment.yml and a binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # mne-gsoc2018-3d
+
 Sandbox for GSoC 2018 3D Viz
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/OlehKSS/mne-gsoc2018-3d/master)

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: mne-gsoc
+
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - numpy
+  - ipyvolume
+  - matplotlib
+  - pythreejs
+  - pysurfer
+  - pip:
+    - mne
+    - nibabel


### PR DESCRIPTION
This adds an environment.yml file so that others (and Binder) can build the environment needed. One snag: it appears we depend on freesurfer for some stuff. Is there a way we can accomplish the same thing without it? 